### PR TITLE
fix: JSON parsing for sensor attributes

### DIFF
--- a/lib/messages/messages.dart
+++ b/lib/messages/messages.dart
@@ -25,7 +25,7 @@ class ClientGenericDeviceMessageAttributes {
 class SensorDeviceMessageAttributes {
   String featureDescriptor = "";
   SensorType sensorType = SensorType.Pressure;
-  List<int> stepCount = [0];
+  List<List<int>> sensorRange = [];
 
   Map<String, dynamic> toJson() => _$SensorDeviceMessageAttributesToJson(this);
   factory SensorDeviceMessageAttributes.fromJson(Map<String, dynamic> json) =>

--- a/lib/messages/messages.g.dart
+++ b/lib/messages/messages.g.dart
@@ -36,15 +36,16 @@ SensorDeviceMessageAttributes _$SensorDeviceMessageAttributesFromJson(
     SensorDeviceMessageAttributes()
       ..featureDescriptor = json['FeatureDescriptor'] as String
       ..sensorType = $enumDecode(_$SensorTypeEnumMap, json['SensorType'])
-      ..stepCount =
-          (json['StepCount'] as List<dynamic>).map((e) => e as int).toList();
+      ..sensorRange = (json['SensorRange'] as List<dynamic>)
+          .map((e) => (e as List<dynamic>).map((e) => e as int).toList())
+          .toList();
 
 Map<String, dynamic> _$SensorDeviceMessageAttributesToJson(
         SensorDeviceMessageAttributes instance) =>
     <String, dynamic>{
       'FeatureDescriptor': instance.featureDescriptor,
       'SensorType': _$SensorTypeEnumMap[instance.sensorType]!,
-      'StepCount': instance.stepCount,
+      'SensorRange': instance.sensorRange,
     };
 
 const _$SensorTypeEnumMap = {


### PR DESCRIPTION
Fix for #1

``SensorDeviceMessageAttributes`` used ``stepCount`` instead of ``sensorRange`` and also used a one dimensional list type (``List<int>``) instead of a two dimensional one (``List<List<int>>``)