### PR TITLE
fix: Await on WebSocket connect to enable exception catching

### DIFF
--- a/lib/connectors/websocket_connector.dart
+++ b/lib/connectors/websocket_connector.dart
@@ -18,6 +18,7 @@ class ButtplugWebsocketClientConnector implements ButtplugClientConnector {
     _wsChannel = WebSocketChannel.connect(
       Uri.parse('ws://127.0.0.1:12345'),
     );
+    await _wsChannel?.ready;
     _wsChannel!.stream.forEach((element) async {
       try {
         List<dynamic> msgs = jsonDecode(element);


### PR DESCRIPTION
Hello,

I've submitted a fix for the error handling during the ButtplugClient.connect() await process.
This ensures exceptions are now catchable. Details are in the attached commits.

Best,